### PR TITLE
Add wakeup-source property to fix wake from sleep

### DIFF
--- a/boards/shields/temper/temper.dtsi
+++ b/boards/shields/temper/temper.dtsi
@@ -32,6 +32,7 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4)  RC(2,5) RC(2,6) RC(2,7) RC(2,8) RC(2,9)
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
         label = "KSCAN";
+        wakeup-source;
 
         diode-direction = "col2row";
         row-gpios


### PR DESCRIPTION
Adds the wakeup-source property to kscan devices. This fixes a bug where the keyboard would fail to wake from sleep, forcing a manual reset to restore functionality. 

See https://zmk.dev/docs/features/low-power-states#wakeup-sources